### PR TITLE
xnviewmp: don't exclude IlmImf.so from dh_shlibdeps

### DIFF
--- a/xnviewmp/rules
+++ b/xnviewmp/rules
@@ -58,8 +58,7 @@ override_dh_installchangelogs:
 	dh_installchangelogs XnView/WhatsNew.txt
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(CURDIR)/debian/xnviewmp/usr/lib/xnviewmp/lib \
-	-XIlmImf.so -Xlibqjpeg.so
+	dh_shlibdeps -l$(CURDIR)/debian/xnviewmp/usr/lib/xnviewmp/lib -Xlibqjpeg.so
 
 override_dh_makeshlibs:
 	dh_makeshlibs -Xusr/lib/xnviewmp


### PR DESCRIPTION
IlmImf.so might not use any symbol from libImath.so.6, but it still uses symbols from other libraries in the libilmbase6 package.
