### PR TITLE
tsmuxer: uncompress upx-compressed binaries

### DIFF
--- a/tsmuxer/control
+++ b/tsmuxer/control
@@ -3,11 +3,15 @@ Section: video
 Priority: optional
 Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
 Build-Depends: debhelper (>= 9),
-               help2man,
+               help2man [i386],
                libc6 [i386],
                libgcc1 [i386],
                libfreetype6 [i386],
-               libqt4-gui [i386]
+               libqtcore4 [i386],
+               libqt4-gui [i386],
+               libstdc++6 [i386],
+               upx-ucl [i386],
+               zlib1g [i386]
 Standards-Version: 3.9.5
 Homepage: http://forum.doom9.org/showthread.php?t=168539
 
@@ -25,10 +29,7 @@ Package: tsmuxer-bin
 Architecture: i386
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         ${shlibs:Depends},
-         libc6,
-         libgcc1,
-         libfreetype6
+         ${shlibs:Depends}
 Description: mux video to TS/M2TS files or create BD disks - files
  tsMuxeR can be run in track detection mode or muxing mode. If run tsMuxeR with
  only one argument then tsMuxeR  display input track information required to
@@ -52,10 +53,6 @@ Architecture: i386
 Multi-Arch: foreign
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         libc6,
-         libgcc1,
-         libfreetype6,
-         libqt4-gui,
          tsmuxer-bin (>= 2)
 Description: mux video to TS/M2TS files or create BD disks - GUI files
  tsMuxeR can be run in track detection mode or muxing mode. If run tsMuxeR with

--- a/tsmuxer/rules
+++ b/tsmuxer/rules
@@ -18,8 +18,8 @@ endif
 	dh_installman
 
 override_dh_strip:
-	upx-ucl -d $(CURDIR)/tsmuxer-bin/usr/lib/tsmuxer/tsMuxeR
-	upx-ucl -d $(CURDIR)/tsmuxergui-bin/usr/lib/tsmuxer/tsMuxerGUI
+	upx-ucl -d $(CURDIR)/debian/tsmuxer-bin/usr/lib/tsmuxer/tsMuxeR
+	upx-ucl -d $(CURDIR)/debian/tsmuxergui-bin/usr/lib/tsmuxer/tsMuxerGUI
 	dh_strip
 
 override_dh_builddeb:

--- a/tsmuxer/rules
+++ b/tsmuxer/rules
@@ -18,7 +18,9 @@ endif
 	dh_installman
 
 override_dh_strip:
-	# stripping will kill the binaries
+	upx-ucl -d $(CURDIR)/tsmuxer-bin/usr/lib/tsmuxer/tsMuxeR
+	upx-ucl -d $(CURDIR)/tsmuxergui-bin/usr/lib/tsmuxer/tsMuxerGUI
+	dh_strip
 
 override_dh_builddeb:
 	dh_builddeb -- -Zxz -z9


### PR DESCRIPTION
The binaries are compressed with UPX. You can use this tool to uncompress them too. The dynamic section in the ELF header can be read after doing so.
These are the dependencies I get:

```
tsmuxer: libc6 (>= 2.4), libgcc1 (>= 1:4.1.1), libstdc++6 (>= 4.2.1), libfreetype6 (>= 2.2.1), zlib1g (>= 1:1.1.4)
tsmuxergui: libc6 (>= 2.1.3), libgcc1 (>= 1:4.1.1), libstdc++6 (>= 4.1.1), libqtcore4 (>= 4:4.7.0~beta1), libqtgui4 (>= 4:4.5.3)
```
